### PR TITLE
Included the assembly in the VSIX

### DIFF
--- a/Glyphfriend.csproj
+++ b/Glyphfriend.csproj
@@ -17,7 +17,7 @@
     <AssemblyName>Glyphfriend</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>


### PR DESCRIPTION
It is very weird that the VSIX project template doesn't do this by default
