### PR TITLE
Updated to next version of VS2015

### DIFF
--- a/GlyphCompletionProviders/BootstrapGlyphCompletionProvider.cs
+++ b/GlyphCompletionProviders/BootstrapGlyphCompletionProvider.cs
@@ -9,124 +9,114 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Glyphfriend.Helpers;
 using Microsoft.CSS.Editor.Completion;
+using Microsoft.VisualStudio.Utilities;
 using TheArtOfDev.HtmlRenderer.WinForms;
 
 namespace Glyphfriend.GlyphCompletionProviders
 {
-	[Export(typeof(ICssCompletionEntryGlyphProvider))]
-	class BootstrapGlyphCompletionProvider : ICssCompletionEntryGlyphProvider
-	{
-		// Store each of the byte[] data for each font for future calls (so that the fonts only have to be generated once)
-		private static Dictionary<string, BitmapFrame> _fontMappings;
+    [Export(typeof(ICssCompletionEntryGlyphProvider))]
+    [Name("Glyphfriend Bootstrap")]
+    [Order(Before = "Default Bootstrap")]
+    class BootstrapGlyphCompletionProvider : ICssCompletionEntryGlyphProvider
+    {
+        // Store each of the byte[] data for each font for future calls (so that the fonts only have to be generated once)
+        private static Dictionary<string, BitmapFrame> _fontMappings;
 
-		// Store the default glyph for this particular library
-		private static BitmapFrame _defaultGlyph = BitmapFrame.Create(new Uri("pack://application:,,,/Glyphfriend;component/Glyphs/Bootstrap/default.png", UriKind.RelativeOrAbsolute));
+        // Define a Regular Expression check for matches from this library
+        private static Regex _regex = new Regex(@"^bootstrap(\.min)?\.css$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-		// Define a Regular Expression check for matches from this library
-		private static Regex _regex = new Regex(@"^bootstrap(\.min)?\.css$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        public BootstrapGlyphCompletionProvider()
+        {
+            // Initialize the Font Awesome icons for the renderer
+            InitializeFonts(GlyphfriendPackage.CurrentSolutionPath);
+            // Find any CSS files associated to the font-awesome library and build the necessary mappings
+            ParseAndGenerateMappings(GlyphfriendPackage.CurrentSolutionPath);
+        }
 
-		public BootstrapGlyphCompletionProvider()
-		{
-			// Initialize the Font Awesome icons for the renderer
-			InitializeFonts(GlyphfriendPackage.CurrentSolutionPath);
-			// Find any CSS files associated to the font-awesome library and build the necessary mappings
-			ParseAndGenerateMappings(GlyphfriendPackage.CurrentSolutionPath);
-		}
+        public ImageSource GetCompletionGlyph(string entryName, Uri sourceUri, CssNameType nameType)
+        {
+            // If the source Uri for the image is null, ignore it
+            if (sourceUri == null) { return null; }
+            // Get the file path of the source being used
+            string filename = Path.GetFileName(sourceUri.ToString()).Trim();
+            // Determine if this matches our filename
+            if (_regex.IsMatch(filename) && _fontMappings.ContainsKey(entryName))
+            {
+                return _fontMappings[entryName];
+            }
 
-		public ImageSource GetCompletionGlyph(string entryName, Uri sourceUri, CssNameType nameType)
-		{
-			// If the source Uri for the image is null, ignore it
-			if (sourceUri == null) { return null; }
-			// Get the file path of the source being used
-			string filename = Path.GetFileName(sourceUri.ToString()).Trim();
-			// Determine if this matches our filename
-			if (_regex.IsMatch(filename))
-			{
-				// At this point, find the font that cooresponds to the existing Glyph and serve it
-				if (_fontMappings.ContainsKey(entryName))
-				{
-					// Add null coalescing to handle errors with Glyph generation
-					return _fontMappings[entryName] ?? _defaultGlyph;
-				}
-				else
-				{
-					// Otherwise return the default Glyph for this library
-					return _defaultGlyph;
-				}
-			}
+            return null;
+        }
 
-			return null;
-		}
+        private void InitializeFonts(string directory)
+        {
+            // Instantiate all Font Awesome True Type fonts that are available (for the renderer)
+            var fonts = new PrivateFontCollection();
 
-		private void InitializeFonts(string directory)
-		{
-			// Instantiate all Font Awesome True Type fonts that are available (for the renderer)
-			var fonts = new PrivateFontCollection();
+            // Get the appropriate fonts that are present within this Project
+            foreach (var fontFamily in Directory.GetFiles(directory, "glyphicons-halflings-regular.ttf", SearchOption.AllDirectories))
+            {
+                fonts.AddFontFile(fontFamily);
+            }
 
-			// Get the appropriate fonts that are present within this Project
-			foreach (var fontFamily in Directory.GetFiles(directory, "glyphicons-halflings-regular.ttf", SearchOption.AllDirectories))
-			{
-				fonts.AddFontFile(fontFamily);
-			}
+            // Add each of the true type fonts to this renderer
+            foreach (var trueTypeFont in fonts.Families)
+            {
+                HtmlRender.AddFontFamily(trueTypeFont);
+            }
+        }
 
-			// Add each of the true type fonts to this renderer
-			foreach (var trueTypeFont in fonts.Families)
-			{
-				HtmlRender.AddFontFamily(trueTypeFont);
-			}
-		}
+        private void ParseAndGenerateMappings(string directory)
+        {
+            // Find the appropriate font-awesome CSS file
+            var path = Directory.EnumerateFiles(directory, "*.css", SearchOption.AllDirectories).Where(f => Regex.IsMatch(f, @"bootstrap(\.min)?\.css")).FirstOrDefault();
 
-		private void ParseAndGenerateMappings(string directory)
-		{
-			// Find the appropriate font-awesome CSS file
-			var path = Directory.EnumerateFiles(directory, "*.css", SearchOption.AllDirectories).Where(f => Regex.IsMatch(f, @"bootstrap(\.min)?\.css")).FirstOrDefault();
+            // Use the file if it was found
+            if (!String.IsNullOrEmpty(path))
+            {
+                // Read in the CSS from the file
+                var css = File.ReadAllText(path);
 
-			// Use the file if it was found
-			if (!String.IsNullOrEmpty(path))
-			{
-				// Read in the CSS from the file 
-				var css = File.ReadAllText(path);
+                // Read only the CSS Classes (only those with :before and beginning with .fa-)
+                var classes = Regex.Matches(css, @"\.[-]?([_a-zA-Z][_a-zA-Z0-9-]*):before|[^\0-\177]*\\[0-9a-f]{1,6}(\r\n[ \n\r\t\f])?|\\[^\n\r\f0-9a-f]*")
+                                   .Cast<Match>()
+                                   .Where(m => m.Value.StartsWith(".glyphicon-") && m.Value.Contains("content:"))
+                                   .Distinct();
 
-				// Read only the CSS Classes (only those with :before and beginning with .fa-)
-				var classes = Regex.Matches(css, @"\.[-]?([_a-zA-Z][_a-zA-Z0-9-]*):before|[^\0-\177]*\\[0-9a-f]{1,6}(\r\n[ \n\r\t\f])?|\\[^\n\r\f0-9a-f]*")
-								   .Cast<Match>()
-								   .Where(m => m.Value.StartsWith(".glyphicon-") && m.Value.Contains("content:"))
-								   .Distinct();
+                // Create a dictionary that maps class names to their respective unicode values
+                Dictionary<string, string> mappings = new Dictionary<string, string>();
 
-				// Create a dictionary that maps class names to their respective unicode values
-				Dictionary<string, string> mappings = new Dictionary<string, string>();
+                // Using those classes, grab the content value that appears within each of them, which will map
+                // the unicode values to the appropriate class
+                foreach (var cssClass in classes)
+                {
+                    // Find the cooresponding code for each class
+                    var unicode = Regex.Match(css, cssClass + "[^\"]*\"(.*)\"[^}]*}");
+                    if (unicode != null && unicode.Groups.Count > 1)
+                    {
+                        // Grab the match and store it
+                        mappings.Add(cssClass.Value.Replace(":before", "").TrimStart('.'), String.Format("&#x{0};", unicode.Groups[1].Value.TrimStart('\\')));
+                    }
+                }
 
-				// Using those classes, grab the content value that appears within each of them, which will map 
-				// the unicode values to the appropriate class 
-				foreach (var cssClass in classes)
-				{
-					// Find the cooresponding code for each class
-					var unicode = Regex.Match(css, cssClass + "[^\"]*\"(.*)\"[^}]*}");
-					if (unicode != null && unicode.Groups.Count > 1)
-					{
-						// Grab the match and store it
-						mappings.Add(cssClass.Value.Replace(":before", "").TrimStart('.'), String.Format("&#x{0};", unicode.Groups[1].Value.TrimStart('\\')));
-					}
-				}
+                // Ensure the font mappings exists
+                _fontMappings = _fontMappings ?? new Dictionary<string, BitmapFrame>();
 
-				// Ensure the font mappings exists
-				_fontMappings = _fontMappings ?? new Dictionary<string, BitmapFrame>();
-
-				// Loop through the available mappings and generate a Glyph for each
-				foreach (var mapping in mappings)
-				{
-					// If the current mapping doesn't exist, add it
-					if (!_fontMappings.ContainsKey(mapping.Key))
-					{
-						// Generate an HTML Snippet to properly render the Glyph
-						var html = String.Format("<span style='font-family: \"Glyphicons Halflings\"; display:block;'>{0}</span>", mapping.Value);
-						// Build a glyphframe
-						var frame = ImageHelper.GenerateGlyph(html);
-						// Store it within the Dictionary
-						_fontMappings.Add(mapping.Key, frame);
-					}
-				}
-			}
-		}
-	}
+                // Loop through the available mappings and generate a Glyph for each
+                foreach (var mapping in mappings)
+                {
+                    // If the current mapping doesn't exist, add it
+                    if (!_fontMappings.ContainsKey(mapping.Key))
+                    {
+                        // Generate an HTML Snippet to properly render the Glyph
+                        var html = String.Format("<span style='font-family: \"Glyphicons Halflings\"; display:block;'>{0}</span>", mapping.Value);
+                        // Build a glyphframe
+                        var frame = ImageHelper.GenerateGlyph(html);
+                        // Store it within the Dictionary
+                        _fontMappings.Add(mapping.Key, frame);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/GlyphCompletionProviders/FoundationGlyphCompletionProvider.cs
+++ b/GlyphCompletionProviders/FoundationGlyphCompletionProvider.cs
@@ -9,12 +9,15 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Glyphfriend.Helpers;
 using Microsoft.CSS.Editor.Completion;
+using Microsoft.VisualStudio.Utilities;
 using TheArtOfDev.HtmlRenderer.WinForms;
 
 namespace Glyphfriend.GlyphCompletionProviders
 {
 	[Export(typeof(ICssCompletionEntryGlyphProvider))]
-	class FoundationGlyphCompletionEntryGlyphProvider : ICssCompletionEntryGlyphProvider
+    [Name("Glyphfriend Foundation")]
+    [Order(Before = "Web Essentials Foundation")]
+    class FoundationGlyphCompletionEntryGlyphProvider : ICssCompletionEntryGlyphProvider
 	{
 		// Store each of the byte[] data for each font for future calls (so that the fonts only have to be generated once)
 		private static Dictionary<string, BitmapFrame> _fontMappings;
@@ -84,7 +87,7 @@ namespace Glyphfriend.GlyphCompletionProviders
 			// Use the file if it was found
 			if (!String.IsNullOrEmpty(path))
 			{
-				// Read in the CSS from the file 
+				// Read in the CSS from the file
 				var css = File.ReadAllText(path);
 
 				// Read only the CSS Classes (only those with :before and beginning with .fa-)
@@ -96,8 +99,8 @@ namespace Glyphfriend.GlyphCompletionProviders
 				// Create a dictionary that maps class names to their respective unicode values
 				Dictionary<string, string> mappings = new Dictionary<string, string>();
 
-				// Using those classes, grab the content value that appears within each of them, which will map 
-				// the unicode values to the appropriate class 
+				// Using those classes, grab the content value that appears within each of them, which will map
+				// the unicode values to the appropriate class
 				foreach (var cssClass in classes)
 				{
 					// Find the cooresponding code for each class

--- a/Glyphfriend.csproj
+++ b/Glyphfriend.csproj
@@ -79,12 +79,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(DevEnvDir)\Extensions\Microsoft\Web Tools\Editors\Microsoft.CSS.Editor.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>False</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.Web.Editor, Version=14.0.0.0">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(DevEnvDir)\Extensions\Microsoft\Web Tools\Editors\Microsoft.Web.Editor.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="System" />

--- a/GlyphfriendPackage.cs
+++ b/GlyphfriendPackage.cs
@@ -12,7 +12,7 @@ namespace Glyphfriend
 	public sealed class GlyphfriendPackage : Package
 	{
 		// Store the current solution path
-		private static string _currentSolutionPath; 
+		private static string _currentSolutionPath;
 
 		internal static string CurrentSolutionPath
 		{
@@ -25,6 +25,7 @@ namespace Glyphfriend
 					{
 						var tempPath = dte2.Solution.FullName;
 						_currentSolutionPath = Path.Combine(new Uri(tempPath).Segments.Take(new Uri(tempPath).Segments.Count() - 1).ToArray());
+                        _currentSolutionPath = _currentSolutionPath.Replace("%20", " "); // Handles space characters
 					}
 				}
 				return _currentSolutionPath;


### PR DESCRIPTION
Hi Rion,

I've made a few modifications to `BootstrapGlyphCompletionProvider.cs` to make it work with the upcoming release of VS2015. First of all, 2 new attributes are added to the class. The `ICssCompletionEntryGlyphProvider` classes need a `Name` attribute and the bootstrap specific one needs an `Order` attribute to make it run before the built-in glyph provider.

I've also removed the _defaultGlyph from the bootstrap specific one since that's no longer needed. If the `GetCompletionGlyph` method returns null, then the next provider takes over. In this case it would be the built-in bootstrap glyph provider.

Finally, I fixed a small issue in the `GlyphfriendPackage.cs` file so it now supports spaces in the project file path.

**Update 1** The addition of the `Order` attribute to the Foundation class is to make sure it works well with Web Essentials