### PR TITLE
Locking to VS2015 RC and newer

### DIFF
--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -10,12 +10,10 @@
 		<Tags>visual studio intellisense, glyph intellisense, font awesome, glyphicons, icon intellisense, foundation, icomoon, ionicons</Tags>
 	</Metadata>
 	<Installation>
-		<InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Pro" />
-		<InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Premium" />
-		<InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Ultimate" />
+		<InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0.22823,)" />
 	</Installation>
 	<Dependencies>
-		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+		<Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
 	</Dependencies>
 	<Assets>
 		<Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />


### PR DESCRIPTION
This prevents the extension from being installed on earlier CTP and Preview builds, since the updated MEF interfaces only work in RC and newer.

Also, only `Microsoft.VisualStudio.Pro` is needed since that will include Community, Pro and Enterprise.