### PR TITLE
Rollback Visual Studio "15" Support

### DIFF
--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -10,9 +10,9 @@
     <Tags>visual studio intellisense, glyph intellisense, font awesome, glyphicons, icon intellisense, foundation, icomoon, ionicons, emojis, emoticons, metroui</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[14.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Pro" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Currently rolling back Visual Studio "15" support until Web Tools are
released for it as otherwise it could cause the IDE to crash and no one
wants that.