### PR TITLE
Load image async

### DIFF
--- a/GlyphfriendPackage.cs
+++ b/GlyphfriendPackage.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.Shell.Interop;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Windows.Media;
@@ -8,8 +6,7 @@ using System.Windows.Media.Imaging;
 
 namespace Glyphfriend
 {
-    [ProvideAutoLoad(UIContextGuids80.SolutionExists)]
-    public sealed class GlyphfriendPackage : Package
+    public sealed class GlyphfriendPackage
     {
         private static Dictionary<string, Dictionary<string,ImageSource>> _glyphs;
         internal static Dictionary<string, Dictionary<string, ImageSource>> Glyphs

--- a/Helpers/HtmlTextViewListener.cs
+++ b/Helpers/HtmlTextViewListener.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.ComponentModel.Composition;
+﻿using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
-using Microsoft.VisualStudio.Text.Editor;
 
 namespace Glyphfriend.Helpers
 {
@@ -16,9 +15,12 @@ namespace Glyphfriend.Helpers
         public void VsTextViewCreated(IVsTextView textViewAdapter)
         {
             // If the Glyphs haven't been loaded, load them
-            if(GlyphfriendPackage.Glyphs == null)
+            if (GlyphfriendPackage.Glyphs == null)
             {
-                GlyphfriendPackage.LoadGlyphs();
+                System.Threading.Tasks.Task.Run(() =>
+                {
+                    GlyphfriendPackage.LoadGlyphs();
+                });
             }
         }
     }

--- a/Helpers/MarkdownTextViewListener.cs
+++ b/Helpers/MarkdownTextViewListener.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.ComponentModel.Composition;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.OLE.Interop;
@@ -7,8 +9,6 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.Utilities;
-using Microsoft.VisualStudio;
-using System.Runtime.InteropServices;
 
 namespace Glyphfriend.Helpers
 {
@@ -28,7 +28,10 @@ namespace Glyphfriend.Helpers
             // If the Emojis haven't been loaded, load them
             if (GlyphfriendPackage.Emojis == null)
             {
-                GlyphfriendPackage.LoadEmojis();
+                System.Threading.Tasks.Task.Run(() =>
+                {
+                    GlyphfriendPackage.LoadEmojis();
+                });
             }
 
             // Set up the Completion handler for Markdown documents
@@ -91,7 +94,7 @@ namespace Glyphfriend.Helpers
                 hresult = Next.Exec(pguidCmdGroup, nCmdID, nCmdexecopt, pvaIn, pvaOut);
             }
 
-            // After the pre-processing has been performed, evaluate the current state 
+            // After the pre-processing has been performed, evaluate the current state
             // and session
             if (ErrorHandler.Succeeded(hresult))
             {
@@ -177,7 +180,7 @@ namespace Glyphfriend.Helpers
             {
                 return false;
             }
-                
+
             // Based off of the available selection, determine if it should be dismissed (via Dismiss) or
             // output (via Commit)
             if (!_currentSession.SelectedCompletionSet.SelectionStatus.IsSelected && !force)
@@ -213,7 +216,7 @@ namespace Glyphfriend.Helpers
             {
                 return false;
             }
-                
+
             // Explicitly cancel the current session
             _currentSession.Dismiss();
 
@@ -223,7 +226,7 @@ namespace Glyphfriend.Helpers
         private bool DoesSessionExist
         {
             // Ensures that the current session exists
-            get { return _currentSession != null;  }
+            get { return _currentSession != null; }
         }
 
         private static char GetTypeChar(IntPtr pvaIn)

--- a/Helpers/MarkdownTextViewListener.cs
+++ b/Helpers/MarkdownTextViewListener.cs
@@ -156,6 +156,13 @@ namespace Glyphfriend.Helpers
             SnapshotPoint caret = _textView.Caret.Position.BufferPosition;
             ITextSnapshot snapshot = caret.Snapshot;
 
+            if (caret > 1)
+            {
+                char prev = snapshot.GetText(caret - 2, 1)[0];
+                if (!char.IsWhiteSpace(prev))
+                    return false;
+            }
+
             // Generate a session based off of the existing broker and textview
             if (!_broker.IsCompletionActive(_textView))
             {


### PR DESCRIPTION
We finally figured out that some of the big VS hangs originated from this extension. This PR fixes it.

This PR loads the images async from the TextViewCreationListener to unblock the UI thread when opening a html/md file. 

It also fixes an issue with the Emoji completion for Markdown so that it is less intrusive. Basically, this suppresses the Emoji completion to happen when the previous character isn't whitespace/line break