### PR TITLE
Allow the solution to load before NuGet restore

### DIFF
--- a/src/Glyphfriend.VS2015/Glyphfriend.VS2015.csproj
+++ b/src/Glyphfriend.VS2015/Glyphfriend.VS2015.csproj
@@ -257,7 +257,7 @@
   </ItemGroup>
   <Import Project="..\Glyphfriend.Core\Glyphfriend.Core.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
   <PropertyGroup>
     <PreBuildEvent>copy "$(SolutionDir)src\Glyphfriend.Packager\Binary\glyphs.bin" "$(ProjectDir)" /y</PreBuildEvent>
   </PropertyGroup>

--- a/src/Glyphfriend.VS2017/Glyphfriend.VS2017.csproj
+++ b/src/Glyphfriend.VS2017/Glyphfriend.VS2017.csproj
@@ -259,7 +259,7 @@
   </ItemGroup>
   <Import Project="..\Glyphfriend.Core\Glyphfriend.Core.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
   <PropertyGroup>
     <PreBuildEvent>copy "$(SolutionDir)src\Glyphfriend.Packager\Binary\glyphs.bin" "$(ProjectDir)" /y</PreBuildEvent>
   </PropertyGroup>


### PR DESCRIPTION
This provides a clean experience for developers using a fresh checkout.